### PR TITLE
Add Delete Mixin

### DIFF
--- a/tg_sdk/abstract/delete_resource.py
+++ b/tg_sdk/abstract/delete_resource.py
@@ -1,0 +1,36 @@
+import requests
+
+from tg_sdk.abstract.api_resource import APIResource
+
+
+class DeleteResourceMixin(APIResource):
+    @classmethod
+    def delete(cls, resource_id, ext=None):
+        """
+        Delete an existing resource.
+            Arguments:
+                resource_id: The unique id of the resource.
+                ext: An extension of the url if extra args are needed.
+                     Does not need the leading or trailing '/'.
+
+            Returns:
+                If a bad request is made then an exception should be raised.
+        """
+        instance = cls()
+        url = "{}/api/v2/{}/{}/".format(
+            instance.core_url,
+            instance.resource,
+            resource_id
+        )
+
+        if ext:
+            url += "{}/".format(ext)
+
+        response = requests.delete(
+            url,
+            headers=instance.default_headers
+        )
+
+        if not response.ok:
+            # TODO(Justin): ADD ERROR HANDLING
+            return


### PR DESCRIPTION
Made the Delete mixin and tested it using Client. Client is being edited in my other PR so I can add those changes when it is pushed. This mixin is going to be used by instances and can also be used as a class method.
Example
```
# Used on an instance
c = tg_sdk.Client.retrieve('id123')
c.disable()

# Used as a class method
tg_sdk.Client.delete('id123')
```
The one thing I was unsure of was if this should return anything other than an error. Also if an instance is used to delete itself should I just make it an empty instance?


EDIT:
I decided I will make changes to the Client class in my next PR. I have a ticket to add the rest of the remaining functionality to Client. 
Also I spoke with Austin and we decided that we should just leave the deleted instance as is and let the API return an error if an requests are made on it.