### PR TITLE
Add custom object strings

### DIFF
--- a/tg_sdk/abstract/retrieve_resource.py
+++ b/tg_sdk/abstract/retrieve_resource.py
@@ -11,6 +11,14 @@ class RetrieveResourceMixin(APIResource):
             return object.__getattribute__(self, attr)
         return None
 
+    def __repr__(self):
+        # Each resource class has a resource class attribute that is the
+        # plural of the resource name. So I am removing the last letter s.
+        return '<{}: {}>'.format(self.resource[:-1].title(), self.name)
+
+    def __str__(self):
+        pass
+
     @classmethod
     def retrieve(cls, resource_id, **params):
         """


### PR DESCRIPTION
An object will return `<{ResourceType}: {ResourceName}` if printed. Should __str__ be the same thing or should it be different?