### PR TITLE
Feature/lazy load iterator

### DIFF
--- a/docs/changlog/README.md
+++ b/docs/changlog/README.md
@@ -1,0 +1,8 @@
+# Changelog
+All changes(internal and external) to this project will be documented in this section.
+
+The format is based on [Keep a Changelog]
+and this project adheres to [Semantic Versioning].
+
+[Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: http://semver.org/spec/v2.0.0.html

--- a/docs/changlog/changelog.md
+++ b/docs/changlog/changelog.md
@@ -1,0 +1,4 @@
+## [Unreleased]
+
+### Added
+- Lazy load list and iterator (Not 100% complete but okay for internal use)

--- a/tg_sdk/abstract/__init__.py
+++ b/tg_sdk/abstract/__init__.py
@@ -13,6 +13,7 @@ from tg_sdk.abstract.delete_resource import DeleteResourceMixin
 from tg_sdk.abstract.list_resource import ListResourceMixin
 from tg_sdk.abstract.post_resource import PostResourceMixin
 from tg_sdk.abstract.put_resource import PutResourceMixin
+from tg_sdk.abstract.lazy_load_list import ResourceList
 from tg_sdk.abstract.retrieve_resource import RetrieveResourceMixin
 from tg_sdk.abstract.error_handling import raise_response_error
 from tg_sdk.abstract.sdk_exception import SDKException
@@ -22,6 +23,7 @@ __all__ = ['APIResource',
            'ListResourceMixin',
            'PostResourceMixin',
            'PutResourceMixin',
+           'ResourceList',
            'RetrieveResourceMixin',
            'raise_response_error',
            'SDKException', ]

--- a/tg_sdk/abstract/api_resource.py
+++ b/tg_sdk/abstract/api_resource.py
@@ -47,20 +47,9 @@ class APIResource(object):
             return super().__setattr__(key, value)
 
     def __repr__(self):
-        resource_name = self.resource
+        resource_name = self.__class__.__name__
 
-        if hasattr(self, 'name'):
-            name = getattr(self, 'name')
-        elif hasattr(self, 'id'):
-            name = getattr(self, 'id')
-        elif hasattr(self, 'id_name'):
-            id_name = getattr(self, 'id_name')
-            name = getattr(self, id_name)
-        else:
-            addr = hex(id(self))
-            return '<{} at {}>'.format(resource_name.title(), addr)
-
-        return '<{}: {}>'.format(resource_name.title(), name)
+        return '<{}: {}>'.format(resource_name.title(), self.id)
 
     @classmethod
     def _construct(cls, **params):

--- a/tg_sdk/abstract/lazy_load_list.py
+++ b/tg_sdk/abstract/lazy_load_list.py
@@ -20,7 +20,7 @@ class LazyLoadMixin:
 
         if lazy:
             start_ind = 0
-            end_ind = 20
+            end_ind = PAGE_SIZE
 
         for i in range(start_ind, end_ind):
             self._data[i] = obj_list[i - start_ind]

--- a/tg_sdk/abstract/lazy_load_list.py
+++ b/tg_sdk/abstract/lazy_load_list.py
@@ -106,6 +106,7 @@ class ResourceList(list, LazyLoadMixin):
             size=self._size,
             data=self._data,
             slice_ind=self._slice_ind,
+            lazy=True,
             *self._ext,
             **self._params
         )
@@ -133,6 +134,9 @@ class ResourceIterator(LazyLoadMixin):
         self._ext = ext
         self._params = params
         self._lazy = self._params.pop('lazy', False)
+    
+    def __iter__(self):
+        return self
 
     def __next__(self):
         if self._ind < self._size:

--- a/tg_sdk/abstract/lazy_load_list.py
+++ b/tg_sdk/abstract/lazy_load_list.py
@@ -1,0 +1,156 @@
+from collections import defaultdict
+from math import floor
+
+from tg_sdk.constants import PAGE_SIZE
+
+
+class LazyLoadMixin:
+    def _update_list(self, offset, lazy=False):
+        """
+        Used to lazy load self._data when an page that has not been loaded
+        is called.
+        """
+        obj_list = self._cls().get_list(
+            offset=offset,
+            *self._ext,
+            **self._params)
+
+        start_ind = offset
+        end_ind = offset + len(obj_list)
+
+        if lazy:
+            start_ind = 0
+            end_ind = 20
+
+        for i in range(start_ind, end_ind):
+            self._data[i] = obj_list[i - start_ind]
+
+    def _get_offset(self, ind):
+        page_number = floor(ind / (PAGE_SIZE))
+        return page_number * PAGE_SIZE
+
+
+class ResourceList(list, LazyLoadMixin):
+    def __init__(self, cls, size=None, data=None, slice_ind=0, *ext, **params):
+        """
+        cls: The class of the objects being listed
+        size: The size of the ResourceList
+              Defaults to count of resources and only used as a kwarg
+              internally on sliced lists.
+        data: A defaultdict containing the objects.
+              Only used as a kwarg for sliced lists.
+        slice_ind: Used to calculate the index of a sliced list since the same
+                   data is used.
+        ext: Strings that need to be added to the end of the URL.
+        params: Extra params for the api call.
+        """
+        self._cls = cls
+        self._size = size or self._cls().get_resource_count(*ext, **params)
+        self._data = data or defaultdict(lambda: None)
+        self._slice_ind = slice_ind
+        self._ext = ext
+        self._params = params
+
+    def __repr__(self):
+        return F"<{self._cls.__name__} ResourceList: {self._size} objects>"
+
+    def __iter__(self):
+        return ResourceIterator(
+            cls=self._cls,
+            size=self._size,
+            data=self._data,
+            slice_ind=self._slice_ind,
+            *self._ext,
+            **self._params
+        )
+
+    def __getitem__(self, ind):
+        """
+        Returns a new instance of ResourceList if a sliced list is needed.
+        """
+        if isinstance(ind, slice):
+            start = ind.start or 0
+            stop = ind.stop or self._size
+            return ResourceList(
+                cls=self._cls,
+                size=stop - start,
+                data=self._data,
+                slice_ind=start,
+                *self._ext,
+                **self._params,
+            )
+        if ind >= self._size:
+            raise IndexError('list index out of range')
+        if ind < 0:
+            # If index negative then get positive index
+            ind += self._size
+        else:
+            # Add offsetting index
+            ind += self._slice_ind
+
+        if self._data[ind] is None:
+            offset = self._get_offset(ind)
+            self._update_list(offset)
+
+        return self._data[ind]
+
+    def __len__(self):
+        return self._size
+
+    def iterator(self):
+        """
+        Returns an iterator which only saves the current page in memory.
+        """
+        return ResourceIterator(
+            cls=self._cls,
+            size=self._size,
+            data=self._data,
+            slice_ind=self._slice_ind,
+            *self._ext,
+            **self._params
+        )
+
+
+class ResourceIterator(LazyLoadMixin):
+    def __init__(self, cls, size, data, slice_ind=0, *ext, **params):
+        """
+        cls: The class of the objects being listed
+        size: The size of the ResourceList
+        data: A defaultdict containing the objects.
+              Only used as a kwarg for sliced lists.
+        offset: The first value on the current page.
+        ind: The current index of the iterator.
+        slice_ind: Used to calculate the index of a sliced list since the same
+                   data is used.
+        ext: Strings that need to be added to the end of the URL.
+        params: Extra params for the api call.
+        """
+        self._cls = cls
+        self._size = size
+        self._data = data
+        self._ind = 0
+        self._slice_ind = slice_ind
+        self._ext = ext
+        self._params = params
+        self._lazy = self._params.pop('lazy', False)
+
+    def __next__(self):
+        if self._ind < self._size:
+            if self._data[self._index] is None:
+                offset = self._get_offset(self._index)
+                self._update_list(offset, self._lazy)
+
+            obj = self._data[self._index]
+            self._ind += 1
+            return obj
+        else:
+            raise StopIteration
+
+    @property
+    def _index(self):
+        ind = self._ind + self._slice_ind
+
+        if self._lazy:
+            ind = ind % PAGE_SIZE
+
+        return ind

--- a/tg_sdk/abstract/lazy_load_list.py
+++ b/tg_sdk/abstract/lazy_load_list.py
@@ -134,7 +134,7 @@ class ResourceIterator(LazyLoadMixin):
         self._ext = ext
         self._params = params
         self._lazy = self._params.pop('lazy', False)
-    
+
     def __iter__(self):
         return self
 

--- a/tg_sdk/abstract/list_resource.py
+++ b/tg_sdk/abstract/list_resource.py
@@ -3,24 +3,35 @@ import requests
 
 from tg_sdk.abstract.api_resource import APIResource
 from tg_sdk.abstract.error_handling import raise_response_error
+from tg_sdk.abstract.lazy_load_list import ResourceList
 
 
 class ListResourceMixin(APIResource):
+
     @classmethod
-    def list(cls, *ext, **params):
+    def list(cls, limit=None, *ext, **params):
+        """
+        Returns a list of resources that will lazy load objects
+        """
+        return ResourceList(cls=cls, *ext, **params)
+
+    def get_list(self, *ext, **params):
         """
         Retrieve multiple resources and return a list of instances of child
         objects initialized with the data received. Any additional filters can
         be added into params as a keyword arg.
 
             Keyword Arguments:
-                instance (object): An instance of the class making
-                                   the retrieval.
-                ext: Strings that are extensions of the url
-                     This should only be used from within resource methods.
+                obj_list = The list of objects to be updated.
+                offset: The starting index of where the list will be updated.
                 limit: The maximum resources that will be returned.
                 raw_data: A boolean value that will tell this method to return
                           the raw list data.
+
+            Optional Arguments:
+                *ext: Strings that are extensions of the url
+                    This should only be used from within resource methods.
+
 
             Returns:
                 list of objects: A list of instances of the child object that
@@ -29,32 +40,34 @@ class ListResourceMixin(APIResource):
                 -or-
                 list of raw data: If raw_data is true.
         """
-        instance = params.pop('instance', None)
-        if not instance:
-            instance = cls()
         resources = []
         raw_data = params.pop('raw_data', False)
-        limit = params.get("limit", None)
-        url = instance._make_url(*ext)
+        url = self._make_url(*ext)
 
-        while url and (limit is None or limit > len(resources)):
-            response = requests.request(
-                "GET",
-                url,
-                headers=instance._default_headers,
-                params=params
-            )
-            if response.ok:
-                data = json.loads(response.text)
-                if raw_data:
-                    new = [res for res in data.get('results', [])]
-                else:
-                    new = [
-                        instance._construct(instance=instance, **res)
-                        for res in data.get('results', [])
-                    ]
-                resources += new
-                url = data.get('next')
+        response = requests.get(
+            url,
+            headers=self._default_headers,
+            params=params
+        )
+        if response.ok:
+            data = json.loads(response.text)
+            if raw_data:
+                return data
             else:
-                raise_response_error(response)
-        return resources[:limit]
+                resources += [
+                    self._construct(**res)
+                    for res in data.get('results', [])
+                ]
+        else:
+            raise_response_error(response)
+
+        return resources
+
+    def get_resource_count(self, *ext, **params):
+        data = self.get_list(
+            *ext,
+            raw_data=True,
+            limit=1,
+            **params
+        )
+        return data.get("count")

--- a/tg_sdk/abstract/post_resource.py
+++ b/tg_sdk/abstract/post_resource.py
@@ -22,12 +22,9 @@ class PostResourceMixin(APIResource):
                 -or-
                 dict of raw data: If raw_data is true.
         """
-        instance = params.pop('instance', None)
-        if not instance:
-            instance = cls()
-
         raw_data = params.pop('raw_data', False)
         instance = params.pop('instance', None)
+
         if not instance:
             instance = cls()
 

--- a/tg_sdk/abstract/tests/test_lazy_load_iterator.py
+++ b/tg_sdk/abstract/tests/test_lazy_load_iterator.py
@@ -1,0 +1,23 @@
+from tg_sdk import Policy
+from tg_sdk._project._decorators import affiliate_test_method
+
+
+@affiliate_test_method
+def test_lazy_iterator():
+    # When using the iterator method in ResourceList only objects at index 0 to
+    # 19 should be initialized
+    resource_objects = Policy.list()
+    ind = 0
+    for i in resource_objects.iterator():
+        if ind == 60:
+            # Stop after 3 pages
+            break
+
+        if ind % 20 == 0:
+            # Test each page for indexes 0 to 19
+            for j in range(60):
+                if j < 20:
+                    assert resource_objects._data[j] is not None
+                else:
+                    assert resource_objects._data[j] is None
+        ind += 1

--- a/tg_sdk/abstract/tests/test_mixins.py
+++ b/tg_sdk/abstract/tests/test_mixins.py
@@ -20,6 +20,12 @@ def test_retrieve_resource():
             objects = data.get('results')
             obj = objects[0]
             id_name = getattr(cls, 'id_name', 'id')
+            alt_id_names = {
+                'Order': 'order_number',
+                'Policy': 'policy_number'
+            }
+            if cls.__name__ in alt_id_names:
+                id_name = alt_id_names[cls.__name__]
 
             # Skip if object is customers since customer does not have an id
             # when listed.
@@ -29,7 +35,6 @@ def test_retrieve_resource():
             # Skip objects that have a null id
             if not obj.get(id_name):
                 for i in objects[1:]:
-
                     if i[id_name]:
                         obj = i
                         break
@@ -42,13 +47,12 @@ def test_retrieve_resource():
 
 @affiliate_test_method
 def test_list_resource():
-
     for attr in vars(tg_sdk):
         cls = getattr(tg_sdk, attr)
         if hasattr(cls, 'resource') and hasattr(cls, 'list'):
             response = requests.request(
                 "GET",
-                cls()._make_url('?limit=50'),
+                cls()._make_url(),
                 headers=cls()._default_headers
             )
             # Get list of objects
@@ -57,9 +61,9 @@ def test_list_resource():
             obj = objects[0]
 
             # Get list using sdk
-            resource_objects = cls().list(limit=50)
+            resource_objects = cls().list()
             assert len(resource_objects) > 0
-            assert len(resource_objects) <= 50
+            assert len(resource_objects) == data.get('count')
 
             for attr in obj:
                 assert hasattr(resource_objects[0], attr)

--- a/tg_sdk/abstract/tests/test_resourcelist.py
+++ b/tg_sdk/abstract/tests/test_resourcelist.py
@@ -1,0 +1,20 @@
+from tg_sdk._project._decorators import affiliate_test_method
+from tg_sdk import Policy
+
+
+@affiliate_test_method
+def test_resourcelist_lazy_loads():
+    # This tests that after each load the unloaded objects in the
+    # list remain none.
+    resource_objects = Policy.list()
+    end = resource_objects._size if resource_objects._size < 60 else 60
+    for i in range(0, end, 20):
+        resource_objects[i]
+        for j in range(0, end):
+            if j <= i + 19:
+                # if j < i + 19 then that page has been loaded so all should
+                # not be None
+                assert resource_objects._data[j] is not None
+            else:
+                # If j is greater than i then it should be None
+                assert resource_objects._data[j] is None

--- a/tg_sdk/constants.py
+++ b/tg_sdk/constants.py
@@ -9,3 +9,4 @@ CORE_SANDBOX = 'https://connect-sandbox.ticketguardian.net'
 ENV = 'prod'
 PUBLIC_KEY = ""
 SECRET_KEY = ""
+PAGE_SIZE = 20

--- a/tg_sdk/order/order.py
+++ b/tg_sdk/order/order.py
@@ -18,7 +18,10 @@ class Order(
         PutResourceMixin, ):
 
     resource = "orders"
-    id_name = "order_number"
+
+    @property
+    def id(self):
+        return self.order_number
 
     @property
     def client(self):

--- a/tg_sdk/policy/policy.py
+++ b/tg_sdk/policy/policy.py
@@ -14,7 +14,10 @@ class Policy(
         ListResourceMixin):
 
     resource = 'policies'
-    id_name = 'policy_number'
+
+    @property
+    def id(self):
+        return self.policy_number
 
     @property
     def item(self):

--- a/tg_sdk/quote/quote.py
+++ b/tg_sdk/quote/quote.py
@@ -4,6 +4,9 @@ from tg_sdk.abstract import PostResourceMixin
 class Quote(PostResourceMixin):
     resource = "quote"
 
-    def __init__(self, items, currency='USD'):
+    def __init__(self, currency='USD', **params):
         super().__init__()
-        self.create(instance=self, items=items, currency=currency)
+        self.create(
+            instance=self,
+            items=params.get('items'),
+            currency=currency)


### PR DESCRIPTION
Expands on the previous sdk PR and adds a method `iterator()` which will only save the current page of resource objects returned from the api.
https://ticketguardian.atlassian.net/browse/BE-160