### PR TITLE
Hotfix/1.1.1

### DIFF
--- a/docs/changlog/changelog.md
+++ b/docs/changlog/changelog.md
@@ -1,3 +1,11 @@
+## [1.1.1] 3/4/2019
+### Added
+ - backwards compatibility testing with `tox`
+ - qa support
+
+### Fixed
+ - Quote failing to set `token`
+
 ## [1.1.0] 2/4/2019
 ### Updated
  - Compatibility with Python2.7

--- a/docs/changlog/changelog.md
+++ b/docs/changlog/changelog.md
@@ -1,4 +1,4 @@
-## [1.1.1] 3/4/2019
+## [1.1.1] 4/4/2019
 ### Added
  - backwards compatibility testing with `tox`
  - qa support

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@ __version__ = '1.1.0'
 
 import os
 
-requirements = []
-
-for file in os.listdir("./requirements/dep/"):
-    with open('./requirements/dep/{}'.format(file)) as f:
-        requirements += f.read().splitlines()
-
 setup(
     name='ticketguardian-python',
     packages=find_packages(exclude=['test*']),
@@ -19,6 +13,6 @@ setup(
     author_email='developers@protecht.io',
     url='https://github.com/TicketGuardian/ticketguardian-python',
     keywords=['sdk', 'TicketGuardian', 'python'],
-    install_requires=requirements,
+    install_requires=['PyJWT==1.5.3', 'simplejson==3.16.0', 'requests[security]'],
     classifiers=[],
 )

--- a/ticketguardian/constants.py
+++ b/ticketguardian/constants.py
@@ -6,6 +6,26 @@ BILLING_SANDBOX = "https://billing-sandbox.ticketguardian.net"
 CORE_DEV = "https://connect.ticketguardian-dev.net"
 CORE_PROD = 'https://connect.ticketguardian.net'
 CORE_SANDBOX = 'https://connect-sandbox.ticketguardian.net'
+CORE_QA = 'https://connect.ticketguardian-qa.com'
+
+DOMAINS = {
+    "dev": {
+        "core": CORE_DEV,
+        "billing": BILLING_DEV
+    },
+    "sandbox": {
+        "core": CORE_SANDBOX,
+        "billing": BILLING_SANDBOX
+    },
+    "qa": {
+        "core": CORE_QA
+    },
+    "prod": {
+        "core": CORE_PROD,
+        "billing": BILLING_PROD
+    }
+}
+
 PUBLIC_KEY = ""
 SECRET_KEY = ""
 ENVIRONMENT = 'prod'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+# content of: tox.ini , put in same dir as setup.py
+[tox]
+envlist = py27, py36
+
+[testenv]
+# install pytest in the virtualenv where commands will be executed
+deps = pytest
+       
+commands =
+    # NOTE: you can run any command line tool here - not just tests
+    pip install virtualenv
+	python -m virtualenv venv
+    {toxinidir}/venv/bin/pip install .
+	{toxinidir}/venv/bin/pip install -r requirements/dev.txt
+    {toxinidir}/venv/bin/python -m pytest


### PR DESCRIPTION
## [1.1.1] 4/4/2019
### Added
 - backwards compatibility testing with `tox`
 - qa support

### Fixed
 - Quote failing to set `token`


I was asked by Gerwin and Ron last night to add QA support to sdk so we are able to properly use Nota on QA. I added it in quickly so we can have support for QA but I would like to revisit this another time and change how environments are handled. It would be nice if we could dynamically create urls rather than storing them all as constants.